### PR TITLE
Catch explicit None parameter in TWdOpeDiv.__init__()

### DIFF
--- a/livemaker/lsb/novel.py
+++ b/livemaker/lsb/novel.py
@@ -298,9 +298,9 @@ class TWdOpeDiv(BaseTWdGlyph):
         super().__init__(**kwargs)
         self._keys.update(("align", "padleft", "padright", "noheight"))
         self.align = int(align)
-        self.padleft = int(padleft)
-        self.padright = int(padright)
-        self.noheight = int(noheight)
+        self.padleft = int(padleft or 0)
+        self.padright = int(padright or 0)
+        self.noheight = int(noheight or 0)
 
     def __str__(self):
         attrs = {

--- a/livemaker/lsb/novel.py
+++ b/livemaker/lsb/novel.py
@@ -297,7 +297,7 @@ class TWdOpeDiv(BaseTWdGlyph):
     def __init__(self, align=0, padleft=0, padright=0, noheight=0, **kwargs):
         super().__init__(**kwargs)
         self._keys.update(("align", "padleft", "padright", "noheight"))
-        self.align = int(align)
+        self.align = int(align or 0)
         self.padleft = int(padleft or 0)
         self.padright = int(padright or 0)
         self.noheight = int(noheight or 0)

--- a/tests/test_badpadding.py
+++ b/tests/test_badpadding.py
@@ -1,0 +1,18 @@
+from livemaker.lsb import novel
+import pytest
+
+def test_padding_is_none():
+
+    # This throws a type error
+    with pytest.raises(TypeError):
+        int(None)
+
+    # Passing nothing is fine
+    novel.TWdOpeDiv()
+
+    # Explicitly passing None will bypass the parameter defaults of 0
+    novel.TWdOpeDiv(padright=None, padleft=None, align=None, noheight=None)
+
+
+if __name__ == "__main__":
+    test_padding_is_none()

--- a/tests/test_badpadding.py
+++ b/tests/test_badpadding.py
@@ -1,6 +1,7 @@
 from livemaker.lsb import novel
 import pytest
 
+
 def test_padding_is_none():
 
     # This throws a type error


### PR DESCRIPTION
Observed text with padding that is parsed into expicit "None" types, which bypasses the parameter defaults and throws a type error.